### PR TITLE
Add contributor list

### DIFF
--- a/doc/content/specs/nidm-overview.html
+++ b/doc/content/specs/nidm-overview.html
@@ -15,6 +15,38 @@
                     company: "University of Washington",
                     companyURL: "http://www.ibic.washington.edu/" }
             ],
+            otherLinks: [{
+            key: "Contributors",
+            data: [{
+                    value: "Tibor Auer",
+                }, {
+                    value: "Gully Burns",
+                }, {
+                    value: "Fariba Fana",
+                }, {
+                    value: "Guillaume Flandin",
+                }, {
+                    value: "Satrajit Ghosh",
+                }, {
+                    value: "Krzysztof J. Gorgolewski",
+                },{
+                    value: "Karl Helmer",
+                }, {
+                    value: "David Keator",
+                }, {
+                    value: "Camille Maumet",
+                }, {
+                    value: "B. Nolan Nichols",
+                }, {
+                    value: "Thomas Nichols",
+                }, {
+                    value: "Jean-Baptiste Poline",
+                }, {
+                    value: "Jason Steffener",
+                }, {
+                    value: "Jessica Turner",
+                }
+            ]}],
             previousMaturity: "FPWD",
             previousPublishDate: "2013-12-10",
             wg: "NIDASH Working Group",

--- a/doc/content/specs/nidm-primer.html
+++ b/doc/content/specs/nidm-primer.html
@@ -15,6 +15,38 @@
                     company: "University of Washington",
                     companyURL: "http://www.ibic.washington.edu/" }
             ],
+            otherLinks: [{
+            key: "Contributors",
+            data: [{
+                    value: "Tibor Auer",
+                }, {
+                    value: "Gully Burns",
+                }, {
+                    value: "Fariba Fana",
+                }, {
+                    value: "Guillaume Flandin",
+                }, {
+                    value: "Satrajit Ghosh",
+                }, {
+                    value: "Krzysztof J. Gorgolewski",
+                },{
+                    value: "Karl Helmer",
+                }, {
+                    value: "David Keator",
+                }, {
+                    value: "Camille Maumet",
+                }, {
+                    value: "B. Nolan Nichols",
+                }, {
+                    value: "Thomas Nichols",
+                }, {
+                    value: "Jean-Baptiste Poline",
+                }, {
+                    value: "Jason Steffener",
+                }, {
+                    value: "Jessica Turner",
+                }
+            ]}],
             previousMaturity: "FPWD",
             previousPublishDate: "2013-12-10",
             wg: "NIDM Working Group",

--- a/doc/content/specs/nidm-results.html
+++ b/doc/content/specs/nidm-results.html
@@ -21,6 +21,38 @@
 						company:    "INCF",
 						companyURL: "http://wiki.incf.org/mediawiki/index.php/Neuroimaging_Task_Force" }
 						],
+						otherLinks: [{
+			            key: "Contributors",
+			            data: [{
+			                    value: "Tibor Auer",
+			                }, {
+			                	value: "Gully Burns",
+			                }, {
+			                	value: "Fariba Fana",
+			                }, {
+								value: "Guillaume Flandin",
+			                }, {
+			                	value: "Satrajit Ghosh",
+			                }, {
+			                    value: "Krzysztof J. Gorgolewski",
+			                },{
+			                	value: "Karl Helmer",
+			                }, {
+			                	value: "David Keator",
+			                }, {
+			                    value: "Camille Maumet",
+			                }, {
+			                    value: "B. Nolan Nichols",
+			                }, {
+			                    value: "Thomas Nichols",
+			                }, {
+			                    value: "Jean-Baptiste Poline",
+			                }, {
+			                    value: "Jason Steffener",
+			                }, {
+			                    value: "Jessica Turner",
+			                }
+			            ]}],
 						previousMaturity: "FPWD",
 						previousPublishDate:  "2013-12-10",
 						wg:           "NIDASH Working Group",
@@ -51,8 +83,7 @@
 								]
 								,   publisher:  "	Elsevier"
 							},
-						}	
-
+						}
 					};
 					</script>
 					<!-- FIXME: PROV-N should be automatically retreive and not manually included in biblio-->


### PR DESCRIPTION
As discussed at incf-nidash/nidm#111, this pull request add a contributor list to the specification documents.

Are listed as contributors in `NIDM-Results`,  `NIDM-Overview` and  `NIDM-Primer`  all the authors of our [Neuroinformatics 2014 NIDM abstract](https://docs.google.com/document/d/1Rwv_fiC0Re7eXExSX6sjJsNqX1WlSMQub_zpNyI1srQ/edit?usp=sharing).

@nicholsn, do you think you could similarly include a contributor list for `nidm-experiment` and `nidm-datasetdescriptors`?
