### PR TITLE
Fix: issue with duplicate base prefix

### DIFF
--- a/nidm/nidm-experiment/terms/nidm-experiment.owl
+++ b/nidm/nidm-experiment/terms/nidm-experiment.owl
@@ -1,4 +1,4 @@
-@prefix : <http://purl.obolibrary.org/obo/iao/dev/ontology-metadata.owl#> .
+@prefix meta: <http://purl.obolibrary.org/obo/iao/dev/ontology-metadata.owl#> .
 @prefix ro: <http://www.obofoundry.org/ro/ro.owl#> .
 @prefix bfo: <http://www.ifomis.org/bfo/1.1#> .
 @prefix dct: <http://purl.org/dc/terms/> .
@@ -19,7 +19,7 @@
 @prefix owl2xml: <http://www.w3.org/2006/12/owl2-xml#> .
 @prefix protege: <http://protege.stanford.edu/plugins/owl/protege#> .
 @prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#> .
-@base <http://purl.org/nidash/nidm/experiment> .
+@prefix : <http://purl.org/nidash/nidm/experiment#> .
 
 <http://purl.org/nidash/nidm/experiment> rdf:type owl:Ontology ;
                                          


### PR DESCRIPTION
When opening `nidm-experiment.owl` into protege, the NIDM-experiment terms are not recognised as being part of the nidm namespace (but rather from IAO metadata, cf. example with `Acquisition Object` below):
![image](https://cloud.githubusercontent.com/assets/5374264/5810983/0b1f0f3c-a004-11e4-86ab-119ba324d6a6.png)

This is a small update to fix this issue.
